### PR TITLE
fix(ui): adjust privacy button layout in dataset creation form

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.html
@@ -50,31 +50,23 @@
         </div>
       </div>
     </div>
-    <nz-switch
-      class="public-status"
-      *ngIf="!isCreatingVersion"
-      [ngModel]="isDatasetPublic"
-      (ngModelChange)="onPublicStatusChange($event)"
-      nzCheckedChildren="public"
-      nzUnCheckedChildren="private">
-    </nz-switch>
+
+    <button
+      nz-button
+      nzType="primary"
+      (click)="onClickCreate()"
+      [disabled]="isCreateButtonDisabled || isCreating"
+      class="create-btn">
+      Create
+    </button>
+
+    <button
+      nz-button
+      nzType="default"
+      (click)="onClickCancel()"
+      class="cancel-btn"
+      [disabled]="isCreating">
+      Cancel
+    </button>
   </nz-spin>
-
-  <button
-    nz-button
-    nzType="primary"
-    (click)="onClickCreate()"
-    [disabled]="isCreateButtonDisabled || isCreating"
-    class="create-btn">
-    Create
-  </button>
-
-  <button
-    nz-button
-    nzType="default"
-    (click)="onClickCancel()"
-    class="cancel-btn"
-    [disabled]="isCreating">
-    Cancel
-  </button>
 </div>

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.scss
@@ -66,10 +66,6 @@
   margin: auto;
 }
 
-.public-status {
-  margin-left: 45px;
-}
-
 .dataset-toggles {
   margin-top: 16px;
   margin-bottom: 16px;


### PR DESCRIPTION
### **Purpose:**
This PR refines the layout of the privacy control button in the dataset creation form to improve clarity.

### **Changes**
- Reverted `user-dataset-version-creator.component.html` to align with the Texera implementation
- Removed unused styles from `user-dataset-version-creator.component.scss`

### **Demonstration**
| Before | After |
|--------|-------|
| <img width="540" alt="before" src="https://github.com/user-attachments/assets/ec4fcfd5-0db0-4a57-858f-4bff61bc2d35" /> | <img width="548" alt="after" src="https://github.com/user-attachments/assets/e8fdb7bd-3a70-488d-b20f-d5788c99a53a" /> |
